### PR TITLE
fix argv parsing in __wrap_main

### DIFF
--- a/pctest/syscode.c
+++ b/pctest/syscode.c
@@ -227,6 +227,8 @@ int __wrap_main(int argc, char **argv) {
 	sys_data.mac = 0xd0;
 	sys_data.scaler = 0;
 
+	int real_argc = argc;
+	char **real_argv = argv;
 	if (argc) argc--, argv++;
 	while (argc) {
 		if (argc >= 2 && !strcmp(argv[0], "--scaler")) {
@@ -276,7 +278,7 @@ int __wrap_main(int argc, char **argv) {
 		exit(1);
 	}
 
-	ret = __real_main(argc, argv);
+	ret = __real_main(real_argc, real_argv);
 	if (sdl_surface) SDL_FreeSurface(sdl_surface);
 #if SDL_MAJOR_VERSION >= 2
 	if (sdl_window) SDL_DestroyWindow(sdl_window);


### PR DESCRIPTION
the parsing loop shifts the argv pointer, meaning leftover arguments passed to __real_main become misaligned. for example, running ./gnuboy.bin zelda.gb leaves zelda.gb as argv[0]. since the engine assumes argv[0] is the executable name, it ignores it, checks argv[1], and fails with a "no rom found" error. i cached real_argc and real_argv at the top and passed them down untouched so the engine can parse the full original command line properly.